### PR TITLE
fix the misformed package-lock json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1738,7 +1738,7 @@
         "@babel/runtime": "^7.9.2",
         "@wordpress/babel-plugin-import-jsx-pragma": "^2.5.0",
         "@wordpress/browserslist-config": "^2.6.0",
-        '@wordpress/element': "^2.13.0",
+        "@wordpress/element": "^2.13.0",
         "@wordpress/warning": "^1.1.0",
         "core-js": "^3.6.4"
       },
@@ -1766,7 +1766,7 @@
       "integrity": "sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA==",
       "dev": true
     },
-    '@wordpress/element': {
+    "@wordpress/element": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.13.0.tgz",
       "integrity": "sha512-jPJ/rFnZJfvZxTnb6XyUlD/mtf+rF9oP0oDtInbr8utjJFhAZ5S2e4EymGmP0trKUCJRIE/NRKYx+Du6xOJSYA==",


### PR DESCRIPTION
Hey Brian,

I accidentally linted the package-lock.json on my last commit here. This pull fixes that and restores the package-lock.json to my tested version.